### PR TITLE
feat: Add udev operation mode

### DIFF
--- a/60-media-automount.rules
+++ b/60-media-automount.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="block", ATTRS{removable}=="0", KERNEL=="sd[a-z][0-9]|nvme[0-9]n[0-9]p[0-9]", ENV{DEVTYPE}=="partition", RUN+="media-automount-udev %p"

--- a/60-media-automount.rules
+++ b/60-media-automount.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="block", ATTRS{removable}=="0", KERNEL=="sd[a-z][0-9]|nvme[0-9]n[0-9]p[0-9]", ENV{DEVTYPE}=="partition", RUN+="media-automount-udev %p"
+ACTION=="add", SUBSYSTEM=="block", ATTRS{removable}=="0", KERNEL=="sd[a-z][0-9]|nvme[0-9]n[0-9]p[0-9]", ENV{DEVTYPE}=="partition", RUN+="media-automount-udev $env{DEVNAME}"

--- a/60-media-automount.rules
+++ b/60-media-automount.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="block", ATTRS{removable}=="0", KERNEL=="sd[a-z][0-9]|nvme[0-9]n[0-9]p[0-9]", ENV{DEVTYPE}=="partition", RUN+="media-automount-udev $env{DEVNAME}"
+ACTION=="add", SUBSYSTEM=="block", ATTRS{removable}=="0", KERNEL=="sd[a-z][0-9]|nvme[0-9]n[0-9]p[0-9]", ENV{DEVTYPE}=="partition", RUN+="/usr/bin/systemd-run --no-block --collect -E MAU_ISBACKGROUND=1 -E ID_FS_TYPE -E ID_FS_UUID /usr/lib/udev/media-automount-udev $env{DEVNAME}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Systemd-generator for partition automounting for internal disks.
+Systemd-generator/udev rules for partition automounting for internal disks.
 
 In inspiration of [Ferk/udev-media-automount](https://github.com/Ferk/udev-media-automount).
 
@@ -10,6 +10,12 @@ cd ./media-automount-generator
 ```
 
 ```shell
+# Run only one of them
+
+# udev mode (recommended)
+./install_udev.sh
+
+# Systemd-generator mode
 ./install.sh
 ```
 

--- a/install_udev.sh
+++ b/install_udev.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exec 2> >(printf '%s: ' "$(date)" "$(</dev/stdin)" | tee -ia log.txt >&2)
+
+cd "$(dirname "$0")" || exit 1
+
+DESTDIR=${DESTDIR:-/usr}
+install_locs="media-automount-generator $DESTDIR/lib/udev/media-automount-udev
+              60-media-automount.rules /etc/udev/rules.d/60-media-automount.rules
+              media-automount.d $DESTDIR/lib/media-automount.d"
+
+placeIn() {
+    local src=${1:?}
+    local dest=${2:?}
+
+    if [[ ! -e $src ]]; then
+        echo >&2 "File $src does not exists"
+        return 1
+    fi
+    mkdir -vp "$(dirname "$dest")"
+    cp -vTrd "$src" "$dest"
+}
+
+if [[ $EUID -ne 0 ]]; then
+    echo >&2 "WARNING: you might lack permissions to write to the directories. Try with 'sudo' if doesnt work."
+fi
+
+ACTION=${1:-install}
+case $ACTION in
+install)
+    while read -r _k _v; do
+        placeIn "$_k" "$_v"
+    done <<<"$install_locs"
+    unset -v _k
+    ;;
+uninstall | remove | rm | delete)
+    while read -r _ _v; do
+        rm -vr "$_v"
+    done <<<"$install_locs"
+    ;;
+*)
+    echo >&2 "Action no supported: $ACTION"
+    exit 1
+    ;;
+esac

--- a/install_udev.sh
+++ b/install_udev.sh
@@ -7,7 +7,7 @@ exec 2> >(printf '%s: ' "$(date)" "$(</dev/stdin)" | tee -ia log.txt >&2)
 cd "$(dirname "$0")" || exit 1
 
 DESTDIR=${DESTDIR:-/usr}
-install_locs="media-automount-generator $DESTDIR/lib/udev/media-automount-udev
+install_locs="media-automount-generator /usr/lib/udev/media-automount-udev
               60-media-automount.rules /etc/udev/rules.d/60-media-automount.rules
               media-automount.d $DESTDIR/lib/media-automount.d"
 

--- a/media-automount-generator
+++ b/media-automount-generator
@@ -161,7 +161,7 @@ OPER_UDEV() {
         --no-block \
         ${FSOPTIONS:+-o "$FSOPTIONS"} \
         ${FSTYPE:+-t $FSTYPE} \
-        "$dev" MOUNTDIR_PARENT/"${ID_FS_UUID:?Missing ID_FS_UUID env var from udev}" >(log "$dev: $(</dev/stdin)") 2>&1
+        "$dev" MOUNTDIR_PARENT/"${ID_FS_UUID:?Missing ID_FS_UUID env var from udev}" > >(log "$dev: $(</dev/stdin)") 2>&1
 }
 
 #@entrypoint

--- a/media-automount-generator
+++ b/media-automount-generator
@@ -125,6 +125,13 @@ OPER_UDEV() {
         exit 1
     fi
 
+    # Check if we are disabling with a /dev/null symlink
+    local _g; _g=$(get_filesystem_conf _all)
+    if [[ $(realpath "$_g") == /dev/null ]]; then
+        log "$dev: /dev/null symlink at $_g. Exiting..."
+        exit 0
+    fi && unset -v _g
+
     # We are using udev rules to filter out removable/invalid devices.
 
     # Check if the dev is listed in fstab

--- a/media-automount-generator
+++ b/media-automount-generator
@@ -102,6 +102,11 @@ trap '_on_err' ERR
 #
 # The script should be placed at '/usr/lib/udev/media-automount-udev'.
 OPER_UDEV() {
+    exec 2> >(tee -ia /tmp/media-automount-udev.log 2>&1)
+
+    log() {
+        echo "$*" >&2
+    }
     # Detect whenever we are a background process.
     #
     # If we are not, reexecute this script in a non-blocking fashion,

--- a/media-automount-generator
+++ b/media-automount-generator
@@ -8,7 +8,6 @@ if [[ ${DEBUG:-0} -eq 1 ]]; then
     set -x
 fi
 
-declare -r UNITS_DIR=${1:?}
 declare -r MOUNTDIR_PARENT="/media/media-automount"
 # Config files should be imported, first ones step over the others:
 #   - /etc/media-automount.d
@@ -96,68 +95,140 @@ trap '_on_err' ERR
 
 #############################################################
 
-# Dont run if we are in a container or a virtual machine
-if [[ -n ${SYSTEMD_VIRTUALIZATION:-} ]]; then
-    log "System is running in ${SYSTEMD_VIRTUALIZATION}, skipping..."
-    exit 0
-fi
+#region Entrypoint
 
-# Check if generator is wanted to be enabled.
-# WARNING: This only should be used by the system admin and not the vendor.
-# WARNING: This file SHOULD NOT contain any configuration.
-# It is meant to be a global /dev/null symlink.
-global_conf_file=$(get_filesystem_conf _all)
+#@entrypoint
+# Entrypoint for udev mode.
+#
+# The script should be placed at '/usr/lib/udev/media-automount-udev'.
+OPER_UDEV() {
+    # Detect whenever we are a background process.
+    #
+    # If we are not, reexecute this script in a non-blocking fashion,
+    # like `systemd-mount --no-block` does.
+    if [[ ${MAU_ISBACKGROUND:-0} -ne 1 ]]; then
+        log "Reexecuting as background process..."
+        MAU_ISBACKGROUND=1 $(realpath -s $0) "$@" & disown
+        exit
+    fi
 
-# Iterate in a list of partitions
-for dev in $(systemd-mount --list --no-pager --no-legend --full | cut -d' ' -f1); do
-    # Check if the device is already set for mounting, and if is, skip it
+    readonly dev=${1:?}
+
+    # Assert dev path matches '/dev/*', just to be sure
+    if [[ ! $dev != /dev/* ]]; then
+        log "$dev: Device does not match pattern '/dev/*'. Aborting..."
+        exit 1
+    fi
+
+    # We are using udev rules to filter out removable/invalid devices.
+
+    # Check if the dev is listed in fstab
     if is_in_fstab "$dev"; then
-        log "$dev: device is already mounted. Skipping..."
-        continue
+        log "$dev: Device is already listed in fstab. Exiting..."
+        exit 0
     fi
 
-    # Ensure we are not dealing with LUKS or LVM devices
-    if [[ $dev == /dev/mapper/* || $dev =~ /dev/dm-[[:digit:]] ]]; then
-        log "$dev: device might be LUKS or LVM. Skipping..."
-        continue
-    fi
+    # Search for a config file matching the partition filesystem
+    local config_file
+    config_file="$(get_filesystem_conf "${ID_FS_TYPE:?Missing ID_FS_TYPE env var from udev}")"
 
-    # Check if is removable, and if so, skip it
-    parent_dev=$(lsblk -n --inverse --output=NAME --filter='TYPE == "disk"' "$dev" | tail -1)
-    if [[ $(</sys/block/"$parent_dev"/removable) -eq 1 ]]; then
-        log "$dev: device is removable. Skipping..."
-        continue
-    fi
+    # Handle config_file readability
+    case $(realpath "$config_file") in
+    "")
+        log "$dev: Config for filesystem $ID_FS_TYPE was not found"
+        exit 0;;
 
-    # Check if we have a config for the partition type
-    fstype=$(lsblk -n --output FSTYPE "$dev")
-    [[ -z $fstype ]] && continue
-    conf_file=${global_conf_file:-$(get_filesystem_conf "$fstype")}
-    if [[ -z $conf_file ]]; then
-        log "$dev: Config for filesystem $fstype was not found"
-        continue
-    elif [[ $(realpath "$conf_file") == /dev/null ]]; then # When the file is a symlink pointing at /dev/null
+    /dev/null)
         log "$dev: Masking conf file $conf_file pointing at /dev/null. Skipping..."
-        continue
+        exit 0;;
+    esac
+    log "$dev: Config file found at $conf_file"
+
+    # Load options from config file
+    local _line FSOPTIONS="" FSTYPE=""
+    while read -r _line; do
+        [[ $_line =~ ^FSOPTIONS=(.*)$ ]] && FSOPTIONS="${BASH_REMATCH[1]%%[[:space:]]*}"
+        [[ $_line =~ ^FSTYPE=(.*)$ ]] && FSTYPE="${BASH_REMATCH[1]%%[[:space:]]*}"
+    done <"$conf_file" && unset -v _line
+
+    # Run systemd-mount with the options given
+    systemd-mount \
+        --no-block \
+        ${FSOPTIONS:+-o "$FSOPTIONS"} \
+        ${FSTYPE:+-t $FSTYPE} \
+        "$dev" MOUNTDIR_PARENT/"${ID_FS_UUID:?Missing ID_FS_UUID env var from udev}" >(log "$dev: $(</dev/stdin)") 2>&1
+}
+
+#@entrypoint
+# Entrypoint for systemd-generator mode
+OPER_GENERATOR() {
+
+    # UNITS_DIR is the first parameter passed, despicting the directory
+    # where the units will be generated.
+    declare -r UNITS_DIR=${1:?}
+
+    # Dont run if we are in a container or a virtual machine
+    if [[ -n ${SYSTEMD_VIRTUALIZATION:-} ]]; then
+        log "System is running in ${SYSTEMD_VIRTUALIZATION}, skipping..."
+        exit 0
     fi
 
-    # Load the config file
-    unset -v FSOPTIONS FSTYPE
-    # shellcheck disable=SC1090
-    eval "$(
-        source "$conf_file" >/dev/null
-        echo "${FSOPTIONS@A}"
-        # shellcheck disable=SC2153
-        echo "${FSTYPE@A}"
-    )"
+    # Check if generator is wanted to be enabled.
+    # WARNING: This only should be used by the system admin and not the vendor.
+    # WARNING: This file SHOULD NOT contain any configuration.
+    # It is meant to be a global /dev/null symlink.
+    global_conf_file=$(get_filesystem_conf _all)
 
-    # Write the unit file
-    dev_uuid="$(lsblk -n --output UUID "$dev")"
-    What="UUID=$dev_uuid"
-    Where=$(realpath -m ${MOUNTDIR_PARENT%%/}/"$dev_uuid") # Get device UUID
-    Type=${FSTYPE:-$fstype}
-    unit_file_path="$UNITS_DIR"/"$(systemd-escape -p --suffix=mount "$Where")"
-    cat <<EOF >"$unit_file_path"
+    # Iterate in a list of partitions
+    for dev in $(systemd-mount --list --no-pager --no-legend --full | cut -d' ' -f1); do
+        # Check if the device is already set for mounting, and if is, skip it
+        if is_in_fstab "$dev"; then
+            log "$dev: device is already mounted. Skipping..."
+            continue
+        fi
+
+        # Ensure we are not dealing with LUKS or LVM devices
+        if [[ $dev == /dev/mapper/* || $dev =~ /dev/dm-[[:digit:]] ]]; then
+            log "$dev: device might be LUKS or LVM. Skipping..."
+            continue
+        fi
+
+        # Check if is removable, and if so, skip it
+        parent_dev=$(lsblk -n --inverse --output=NAME --filter='TYPE == "disk"' "$dev" | tail -1)
+        if [[ $(</sys/block/"$parent_dev"/removable) -eq 1 ]]; then
+            log "$dev: device is removable. Skipping..."
+            continue
+        fi
+
+        # Check if we have a config for the partition type
+        fstype=$(lsblk -n --output FSTYPE "$dev")
+        [[ -z $fstype ]] && continue
+        conf_file=${global_conf_file:-$(get_filesystem_conf "$fstype")}
+        if [[ -z $conf_file ]]; then
+            log "$dev: Config for filesystem $fstype was not found"
+            continue
+        elif [[ $(realpath "$conf_file") == /dev/null ]]; then # When the file is a symlink pointing at /dev/null
+            log "$dev: Masking conf file $conf_file pointing at /dev/null. Skipping..."
+            continue
+        fi
+
+        # Load the config file
+        unset -v FSOPTIONS FSTYPE
+        # shellcheck disable=SC1090
+        eval "$(
+            source "$conf_file" >/dev/null
+            echo "${FSOPTIONS@A}"
+            # shellcheck disable=SC2153
+            echo "${FSTYPE@A}"
+        )"
+
+        # Write the unit file
+        dev_uuid="$(lsblk -n --output UUID "$dev")"
+        What="UUID=$dev_uuid"
+        Where=$(realpath -m ${MOUNTDIR_PARENT%%/}/"$dev_uuid") # Get device UUID
+        Type=${FSTYPE:-$fstype}
+        unit_file_path="$UNITS_DIR"/"$(systemd-escape -p --suffix=mount "$Where")"
+        cat <<EOF >"$unit_file_path"
 # Unit generated by ${0}
 [Unit]
 SourcePath=${conf_file}
@@ -171,14 +242,31 @@ Where=${Where:?}
 Type=${Type:?}
 ${FSOPTIONS:+Options=${FSOPTIONS}}
 EOF
-    if [[ ! -s $unit_file_path ]]; then
-        log "$dev: Generated mount unit file at $unit_file_path is empty. Skipping..."
-        continue
-    fi
-    log "$dev: Generated mount unit file at $unit_file_path"
-    mkdir -p "${UNITS_DIR}"/local-fs.target.wants
-    ln -sr "$unit_file_path" "${UNITS_DIR}"/local-fs.target.wants/
-    log "$dev: Symlinked $unit_file_path to ${UNITS_DIR}/local-fs.target.wants/$(basename "$unit_file_path")"
-done
+        if [[ ! -s $unit_file_path ]]; then
+            log "$dev: Generated mount unit file at $unit_file_path is empty. Skipping..."
+            continue
+        fi
+        log "$dev: Generated mount unit file at $unit_file_path"
+        mkdir -p "${UNITS_DIR}"/local-fs.target.wants
+        ln -sr "$unit_file_path" "${UNITS_DIR}"/local-fs.target.wants/
+        log "$dev: Symlinked $unit_file_path to ${UNITS_DIR}/local-fs.target.wants/$(basename "$unit_file_path")"
+    done
 
-log "Unit files were generated. Stopping process..."
+    log "Unit files were generated. Stopping process..."
+
+}
+
+#endregion Entrypoint
+
+#############################################################
+
+# Detect which entrypoint should be used for the script
+case "${0}" in
+*media-automount-udev)
+    OPER_UDEV "$@"
+    exit;;
+*)
+    # Fallback to generator mode by default
+    OPER_GENERATOR "$@"
+    exit;;
+esac

--- a/media-automount-generator
+++ b/media-automount-generator
@@ -134,11 +134,11 @@ OPER_UDEV() {
     fi
 
     # Search for a config file matching the partition filesystem
-    local config_file
-    config_file="$(get_filesystem_conf "${ID_FS_TYPE:?Missing ID_FS_TYPE env var from udev}")"
+    local conf_file
+    conf_file="$(get_filesystem_conf "${ID_FS_TYPE:?Missing ID_FS_TYPE env var from udev}")"
 
     # Handle config_file readability
-    case $(realpath "$config_file") in
+    case $(realpath "$conf_file") in
     "")
         log "$dev: Config for filesystem $ID_FS_TYPE was not found"
         exit 0;;

--- a/media-automount-generator
+++ b/media-automount-generator
@@ -120,7 +120,7 @@ OPER_UDEV() {
     readonly dev=${1:?}
 
     # Assert dev path matches '/dev/*', just to be sure
-    if [[ ! $dev != /dev/* ]]; then
+    if [[ $dev != /dev/* ]]; then
         log "$dev: Device does not match pattern '/dev/*'. Aborting..."
         exit 1
     fi

--- a/media-automount-generator
+++ b/media-automount-generator
@@ -161,7 +161,7 @@ OPER_UDEV() {
         --no-block \
         ${FSOPTIONS:+-o "$FSOPTIONS"} \
         ${FSTYPE:+-t $FSTYPE} \
-        "$dev" MOUNTDIR_PARENT/"${ID_FS_UUID:?Missing ID_FS_UUID env var from udev}" > >(log "$dev: $(</dev/stdin)") 2>&1
+        "$dev" $MOUNTDIR_PARENT/"${ID_FS_UUID:?Missing ID_FS_UUID env var from udev}" > >(log "$dev: $(</dev/stdin)") 2>&1
 }
 
 #@entrypoint


### PR DESCRIPTION
Using udev allows us to simplify device path pattern matching, removability check, and avoids condition races with device discoverability